### PR TITLE
Version 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2.2 (2012-02-22)
+
+* Fixed a data leak in `expire_leaderboard` and `expire_leaderboard_at` to also set expiration on the member data hash.
+
 ## 2.2.1 (2012-12-19)
 
 * Updated `remove_member` to also remove the optional member data for the member being removed.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ highscore_lb.members_from_rank_range(1, 5)
 [{'member': 'member_95', 'score': 95.0, 'rank': 1}, {'member': 'member_94', 'score': 94.0, 'rank': 2}, {'member': 'member_93', 'score': 93.0, 'rank': 3}, {'member': 'member_92', 'score': 92.0, 'rank': 4}, {'member': 'member_91', 'score': 91.0, 'rank': 5}]
 ```
 
+#### Optional member data notes
+
+If you use optional member data, the use of the `remove_members_in_score_range` will leave data around in the member data 
+hash. This is because the internal Redis method, `zremrangebyscore`, only returns the number of items removed. It does 
+not return the members that it removed.
+
 ### Conditionally rank a member in the leaderboard
 
 You can pass a function to the `rank_member_if` method to conditionally rank a member in the leaderboard. The function is passed the following 5 parameters:

--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -9,7 +9,7 @@ def grouper(n, iterable, fillvalue=None):
   return izip_longest(fillvalue=fillvalue, *args)
 
 class Leaderboard(object):
-  VERSION = '2.2.1'
+  VERSION = '2.2.2'
   DEFAULT_PAGE_SIZE = 25
   DEFAULT_REDIS_HOST = 'localhost'
   DEFAULT_REDIS_PORT = 6379
@@ -475,7 +475,10 @@ class Leaderboard(object):
     @param leaderboard_name [String] Name of the leaderboard.
     @param seconds [int] Number of seconds after which the leaderboard will be expired.
     '''
-    self.redis_connection.expire(leaderboard_name, seconds)
+    pipeline = self.redis_connection.pipeline()
+    pipeline.expire(leaderboard_name, seconds)
+    pipeline.expire(self._member_data_key(leaderboard_name), seconds)
+    pipeline.execute()
 
   def expire_leaderboard_at(self, timestamp):
     '''
@@ -494,7 +497,10 @@ class Leaderboard(object):
     @param leaderboard_name [String] Name of the leaderboard.
     @param timestamp [int] UNIX timestamp at which the leaderboard will be expired.
     '''
-    self.redis_connection.expireat(leaderboard_name, timestamp)
+    pipeline = self.redis_connection.pipeline()
+    pipeline.expireat(leaderboard_name, timestamp)
+    pipeline.expireat(self._member_data_key(leaderboard_name), timestamp)
+    pipeline.execute()
 
   def leaders(self, current_page, **options):
     '''

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [req.strip() for req in open('requirements.pip')]
 
 setup(
   name = 'leaderboard',
-  version = "2.2.1",
+  version = "2.2.2",
   author = 'David Czarnecki',
   author_email = "dczarnecki@agoragames.com",
   packages = ['leaderboard'],

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -12,7 +12,7 @@ class LeaderboardTest(unittest.TestCase):
     self.leaderboard.redis_connection.flushdb()
 
   def test_version(self):
-    Leaderboard.VERSION.should.equal('2.2.1')
+    Leaderboard.VERSION.should.equal('2.2.2')
 
   def test_init_with_defaults(self):
     'name'.should.equal(self.leaderboard.leaderboard_name)
@@ -149,11 +149,15 @@ class LeaderboardTest(unittest.TestCase):
     self.leaderboard.expire_leaderboard(3)
     ttl = self.leaderboard.redis_connection.ttl(self.leaderboard.leaderboard_name)
     ttl.should.be.greater_than(1)
+    ttl = self.leaderboard.redis_connection.ttl('%s:member_data' % self.leaderboard.leaderboard_name)
+    ttl.should.be.greater_than(1)
 
   def test_expire_leaderboard_at(self):
     self.__rank_members_in_leaderboard()
     self.leaderboard.expire_leaderboard_at(int(time.time() + 10))
     ttl = self.leaderboard.redis_connection.ttl(self.leaderboard.leaderboard_name)
+    ttl.should.be.lower_than(11)
+    ttl = self.leaderboard.redis_connection.ttl('%s:member_data' % self.leaderboard.leaderboard_name)
     ttl.should.be.lower_than(11)
 
   def test_leaders(self):


### PR DESCRIPTION
- Fixed a data leak in `expire_leaderboard` and `expire_leaderboard_at` to also set expiration on the member data hash.
