### PR TITLE
don't deepcopy options

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -1,5 +1,4 @@
 from redis import Redis, ConnectionPool
-from copy import deepcopy
 import math
 from itertools import izip_longest
 
@@ -46,7 +45,7 @@ class Leaderboard(object):
     connection_pool : redis connection pool to use if creating a new handle
     '''
     self.leaderboard_name = leaderboard_name
-    self.options = deepcopy(options)
+    self.options = options
 
     self.page_size = self.options.pop('page_size', self.DEFAULT_PAGE_SIZE)
     if self.page_size < 1:


### PR DESCRIPTION
I'm actually uncertain why you put it in the first place. My only guess would have to do with thread-safety in the case of a `connection_pool` or `connection` option, but aren't those thread safe anyway?

before
![before](https://f.cloud.github.com/assets/52795/491499/131231b6-ba31-11e2-90b1-e8b69f675741.png)

after
![after](https://f.cloud.github.com/assets/52795/491500/175a8fd4-ba31-11e2-89cb-294872963734.png)
