### PR TITLE
ASC sorted page_for was broken due to a spelling error

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -422,7 +422,7 @@ class Leaderboard(object):
     if self.order == self.DESC:
       rank_for_member = self.redis_connection.zrank(leaderboard_name, member)
     else:
-      rank_for_memebr = self.redis_connection.zrevrank(leaderboard_name, member)
+      rank_for_member = self.redis_connection.zrevrank(leaderboard_name, member)
 
     if rank_for_member == None:
       rank_for_member = 0


### PR DESCRIPTION
I tried to create a test for this but I wasn't able to get that test suite thing to work. 

```
True.should.be(False)
```

wasn't even raising an error.  Never used the testing library before so I might have done something wrong. 
