### PR TITLE
leaders() should return an empty list in case of an empty result set.

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -536,7 +536,7 @@ class Leaderboard(object):
     if raw_leader_data:
       return self.ranked_in_list_in(self.leaderboard_name, raw_leader_data, **options)
     else:
-      return None
+      return []
 
   def all_leaders(self, **options):
     '''

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -194,6 +194,11 @@ class LeaderboardTest(unittest.TestCase):
     leaders[0]['member'].should.equal('member_5')
     leaders[0]['member_data'].should.be(str({'member_name': 'Leaderboard member 5'}))
 
+  def test_leaders_return_type(self):
+    leaders = self.leaderboard.leaders(1)
+    type(leaders).should.equal(type([]))
+    leaders.should.equal([])
+
   def test_ranked_in_list_with_sort_by(self):
     self.__rank_members_in_leaderboard(26)
     leaders = self.leaderboard.ranked_in_list(['member_25', 'member_1', 'member_15'], sort_by = 'score')


### PR DESCRIPTION
Fixed an issue where the `leaders()` function was returning `None` instead of `[]` in case of an empty result set. 
