### PR TITLE
add members_only option. 

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -777,7 +777,7 @@ class Leaderboard(object):
     @return a list of members.
     '''
     if members_only:
-      return members
+      return [{'member': m} for m in members]
 
     if members:
       return self.ranked_in_list_in(leaderboard_name, members, **options)

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -304,7 +304,7 @@ class LeaderboardTest(unittest.TestCase):
     (len(leaders_around_me) / 2).should.equal(self.leaderboard.page_size / 2)
 
   def test_members_only(self):
-    exp = ['member_%d' % x for x in reversed(range(1, 27))]
+    exp = [{'member': 'member_%d' % x} for x in reversed(range(1, 27))]
 
     self.__rank_members_in_leaderboard(27)
     leaders = self.leaderboard.leaders(1, members_only=True)


### PR DESCRIPTION
Haven't added tests for this pull request yet, waiting for  an OK from you.

The idea here is that in some cases you are really just interested in the `member` of the sorted set and you don't care about it's score or rank. In those cases the ranking function will have a negative impact on performance, while the results of it are discarded.

This case applies to your Ruby activity_feed library. In my Python port I could see the following difference by adding this option.

before:
![before](https://f.cloud.github.com/assets/52795/493165/16adb770-bb24-11e2-92e2-d28eaff8f735.png)

after:
![after](https://f.cloud.github.com/assets/52795/493166/1a470cb0-bb24-11e2-8531-9d7584b02300.png)
