### PR TITLE
Add remove_members_in_rank_range

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -401,6 +401,23 @@ class Leaderboard(object):
     '''
     self.redis_connection.zremrangebyscore(leaderboard_name, min_score, max_score)
 
+  def remove_members_in_rank_range(self, min_rank, max_rank):
+    '''
+    Remove members from the leaderboard in a given rank range.
+    @param min_rank [int] Minimum rank.
+    @param max_rank [int] Maximum rank.
+    '''
+    self.remove_members_in_rank_range_in(self.leaderboard_name, min_rank, max_rank)
+
+  def remove_members_in_rank_range_in(self, leaderboard_name, min_rank, max_rank):
+    '''
+    Remove members from the named leaderboard in a given rank range.
+    @param leaderboard_name [String] Name of the leaderboard.
+    @param min_rank [int] Minimum rank.
+    @param max_rank [int] Maximum rank.
+    '''
+    self.redis_connection.zremrangebyrank(leaderboard_name, min_rank, max_rank)
+
   def page_for(self, member, page_size = DEFAULT_PAGE_SIZE):
     '''
     Determine the page where a member falls in the leaderboard.

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -126,6 +126,18 @@ class LeaderboardTest(unittest.TestCase):
     self.leaderboard.remove_members_in_score_range(2, 4)
     self.leaderboard.total_members().should.equal(2)
 
+  def test_remove_members_in_rank_range(self):
+    self.__rank_members_in_leaderboard()
+    self.leaderboard.total_members().should.equal(5)
+    self.leaderboard.remove_members_in_rank_range(2, 4)
+    self.leaderboard.total_members().should.equal(2)
+    # remove every everyone except the leader
+    self.leaderboard.remove_members_in_rank_range(1, -1)
+    self.leaderboard.total_members().should.equal(1)
+    # remove everyone
+    self.leaderboard.remove_members_in_rank_range(0, -1)
+    self.leaderboard.total_members().should.equal(0)
+
   def test_page_for(self):
     self.leaderboard.page_for('jones').should.equal(0)
 


### PR DESCRIPTION
A new remove/trim function which removes members in a certain
rank_range. This is useful if you only want to keep for example the top
members 25 in a leaderboard. You can do
`remove_members_in_rank_range(25, -1)` and it will remove any member
with a rank lower than 25.
