### PR TITLE
Rank members across

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## master ()
+## 2.5.0 (2013-07-17)
 
 * Added `rank_member_across` method to be able to rank a member across multiple leaderboards at once.
 * Fixed bugs in `leaders_in` and `around_me_in` methods that would not correctly use the `leaderboard_name` argument.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ highscore_lb.score_for('david')
 1338.0
 ```
 
+### Ranking a member across multiple leaderboards
+
+```ruby
+highscore_lb.rank_member_across(['highscores', 'more_highscores'], 'david', 50000, { 'member_name': 'david' })
+```
+
 ## Performance Metrics
 
 You can view [performance metrics](https://github.com/agoragames/leaderboard#performance-metrics) for the

--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -8,7 +8,7 @@ def grouper(n, iterable, fillvalue=None):
   return izip_longest(fillvalue=fillvalue, *args)
 
 class Leaderboard(object):
-  VERSION = '2.4.0'
+  VERSION = '2.5.0'
   DEFAULT_PAGE_SIZE = 25
   DEFAULT_REDIS_HOST = 'localhost'
   DEFAULT_REDIS_PORT = 6379

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [req.strip() for req in open('requirements.pip')]
 
 setup(
   name = 'leaderboard',
-  version = "2.4.0",
+  version = "2.5.0",
   author = 'David Czarnecki',
   author_email = "dczarnecki@agoragames.com",
   packages = ['leaderboard'],

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -12,7 +12,7 @@ class LeaderboardTest(unittest.TestCase):
     self.leaderboard.redis_connection.flushdb()
 
   def test_version(self):
-    Leaderboard.VERSION.should.equal('2.4.0')
+    Leaderboard.VERSION.should.equal('2.5.0')
 
   def test_init_with_defaults(self):
     'name'.should.equal(self.leaderboard.leaderboard_name)


### PR DESCRIPTION
- Added `rank_member_across` method to be able to rank a member across multiple leaderboards at once.
- Fixed bugs in `leaders_in` and `around_me_in` methods that would not correctly use the `leaderboard_name` argument.
