### PR TITLE
Allow for customization of member_data namespace

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -13,6 +13,7 @@ class Leaderboard(object):
   DEFAULT_REDIS_HOST = 'localhost'
   DEFAULT_REDIS_PORT = 6379
   DEFAULT_REDIS_DB = 0
+  DEFAULT_MEMBER_DATA_NAMESPACE = 'member_data'
   ASC = 'asc'
   DESC = 'desc'
   MEMBER_KEY = 'member'
@@ -54,6 +55,8 @@ class Leaderboard(object):
     self.page_size = self.options.pop('page_size', self.DEFAULT_PAGE_SIZE)
     if self.page_size < 1:
       self.page_size = self.DEFAULT_PAGE_SIZE
+
+    self.member_data_namespace = self.options.pop('member_data_namespace', self.DEFAULT_MEMBER_DATA_NAMESPACE)
 
     self.order = self.options.pop('order', self.DESC).lower()
     if not self.order in [self.ASC, self.DESC]:
@@ -916,7 +919,7 @@ class Leaderboard(object):
     @param leaderboard_name [String] Name of the leaderboard.
     @return a key in the form of +leaderboard_name:member_data+
     '''
-    return '%s:member_data' % leaderboard_name
+    return '%s:%s' % (leaderboard_name, self.member_data_namespace)
 
   def _parse_raw_members(self, leaderboard_name, members, members_only = False, **options):
     '''

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -453,6 +453,13 @@ class LeaderboardTest(unittest.TestCase):
     lb.rank_for('david').should.equal(1)
     len(lb.leaders(1)).should.equal(1)
 
+  def test_can_set_member_data_namespace_option(self):
+    self.leaderboard = Leaderboard('name', member_data_namespace = 'md')
+    self.__rank_members_in_leaderboard()
+
+    self.leaderboard.redis_connection.exists("name:member_data").should.be.false
+    self.leaderboard.redis_connection.exists("name:md").should.be.true
+
   def __rank_members_in_leaderboard(self, members_to_add = 6):
     for index in range(1, members_to_add):
       self.leaderboard.rank_member('member_%s' % index, index, { 'member_name': 'Leaderboard member %s' % index })


### PR DESCRIPTION
You can now pass in the `member_data_namespace = 'md'` option when creating a leaderboard to customize where member data is stored.
