### PR TITLE
Adding `rank_relative` to ranked_in_list_in()

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -10,7 +10,7 @@ def grouper(n, iterable, fillvalue=None):
 
 
 class Leaderboard(object):
-    VERSION = '2.8.0'
+    VERSION = '2.9.0'
     DEFAULT_PAGE_SIZE = 25
     DEFAULT_REDIS_HOST = 'localhost'
     DEFAULT_REDIS_PORT = 6379
@@ -22,6 +22,7 @@ class Leaderboard(object):
     MEMBER_DATA_KEY = 'member_data'
     SCORE_KEY = 'score'
     RANK_KEY = 'rank'
+    RANK_RELATIVE_KEY = 'rank_relative'
 
     @classmethod
     def pool(self, host, port, db, pools={}):
@@ -966,6 +967,7 @@ class Leaderboard(object):
 
         responses = pipeline.execute()
 
+        score_last = None
         for index, member in enumerate(members):
             data = {}
             data[self.MEMBER_KEY] = member
@@ -977,6 +979,10 @@ class Leaderboard(object):
             if score is not None:
                 score = float(score)
             data[self.SCORE_KEY] = score
+            if score_last is None or score != score_last:
+                rank_relative = index + 1
+            data[self.RANK_RELATIVE_KEY] = rank_relative
+            score_last = score
 
             if ('with_member_data' in options) and (True == options['with_member_data']):
                 data[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [req.strip() for req in open('requirements.pip')]
 
 setup(
   name = 'leaderboard',
-  version = "2.8.0",
+  version = "2.9.0",
   author = 'David Czarnecki',
   author_email = "dczarnecki@agoragames.com",
   packages = ['leaderboard'],

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -319,14 +319,16 @@ class LeaderboardTest(unittest.TestCase):
         member_15 = {
             'member': 'member_15',
             'score': 15.0,
-            'rank': 11
+            'rank': 11,
+            'rank_relative': 1
         }
         members[0].should.eql(member_15)
 
         member_10 = {
             'member': 'member_10',
             'score': 10.0,
-            'rank': 16
+            'rank': 16,
+            'rank_relative': 6
         }
         members[5].should.eql(member_10)
 


### PR DESCRIPTION
For the cases when you want the relative ranks of the specified members in relation to each other (as opposed to their absolute ranks among ALL members in the set)
Fixed broken unit tests and bumped version to 2.9.0
