### PR TITLE
Added param `include_missing` to ranked_in_list()

### DIFF
--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -10,7 +10,7 @@ def grouper(n, iterable, fillvalue=None):
 
 
 class Leaderboard(object):
-    VERSION = '2.10.0'
+    VERSION = '2.8.0'
     DEFAULT_PAGE_SIZE = 25
     DEFAULT_REDIS_HOST = 'localhost'
     DEFAULT_REDIS_PORT = 6379

--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -932,26 +932,22 @@ class Leaderboard(object):
         return self._parse_raw_members(
             leaderboard_name, raw_leader_data, **options)
 
-    def ranked_in_list(self, members, include_missing=True, **options):
+    def ranked_in_list(self, members, **options):
         '''
         Retrieve a page of leaders from the leaderboard for a given list of members.
 
         @param members [Array] Member names.
-        @param include_missing [Boolean] Whether or not to include members that are missing in the results.
         @param options [Hash] Options to be used when retrieving the page from the leaderboard.
         @return a page of leaders from the leaderboard for a given list of members.
         '''
-        return self.ranked_in_list_in(
-            self.leaderboard_name, members, include_missing, **options)
+        return self.ranked_in_list_in(self.leaderboard_name, members, **options)
 
-    def ranked_in_list_in(
-            self, leaderboard_name, members, include_missing=True, **options):
+    def ranked_in_list_in(self, leaderboard_name, members, **options):
         '''
         Retrieve a page of leaders from the named leaderboard for a given list of members.
 
         @param leaderboard_name [String] Name of the leaderboard.
         @param members [Array] Member names.
-        @param include_missing [Boolean] Whether or not to include members that are missing in the results.
         @param options [Hash] Options to be used when retrieving the page from the named leaderboard.
         @return a page of leaders from the named leaderboard for a given list of members.
         '''
@@ -974,7 +970,7 @@ class Leaderboard(object):
             data[self.MEMBER_KEY] = member
             rank = responses[index * 2]
             if rank is None:
-                if not include_missing:
+                if options.get('include_missing') == False:
                     continue
             else:
                 rank += 1

--- a/leaderboard/__init__.py
+++ b/leaderboard/__init__.py
@@ -10,7 +10,7 @@ def grouper(n, iterable, fillvalue=None):
 
 
 class Leaderboard(object):
-    VERSION = '2.8.0'
+    VERSION = '2.10.0'
     DEFAULT_PAGE_SIZE = 25
     DEFAULT_REDIS_HOST = 'localhost'
     DEFAULT_REDIS_PORT = 6379
@@ -932,23 +932,26 @@ class Leaderboard(object):
         return self._parse_raw_members(
             leaderboard_name, raw_leader_data, **options)
 
-    def ranked_in_list(self, members, **options):
+    def ranked_in_list(self, members, include_missing=True, **options):
         '''
         Retrieve a page of leaders from the leaderboard for a given list of members.
 
         @param members [Array] Member names.
+        @param include_missing [Boolean] Whether or not to include members that are missing in the results.
         @param options [Hash] Options to be used when retrieving the page from the leaderboard.
         @return a page of leaders from the leaderboard for a given list of members.
         '''
         return self.ranked_in_list_in(
-            self.leaderboard_name, members, **options)
+            self.leaderboard_name, members, include_missing, **options)
 
-    def ranked_in_list_in(self, leaderboard_name, members, **options):
+    def ranked_in_list_in(
+            self, leaderboard_name, members, include_missing=True, **options):
         '''
         Retrieve a page of leaders from the named leaderboard for a given list of members.
 
         @param leaderboard_name [String] Name of the leaderboard.
         @param members [Array] Member names.
+        @param include_missing [Boolean] Whether or not to include members that are missing in the results.
         @param options [Hash] Options to be used when retrieving the page from the named leaderboard.
         @return a page of leaders from the named leaderboard for a given list of members.
         '''
@@ -970,7 +973,10 @@ class Leaderboard(object):
             data = {}
             data[self.MEMBER_KEY] = member
             rank = responses[index * 2]
-            if rank is not None:
+            if rank is None:
+                if not include_missing:
+                    continue
+            else:
                 rank += 1
             data[self.RANK_KEY] = rank
             score = responses[index * 2 + 1]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [req.strip() for req in open('requirements.pip')]
 
 setup(
   name = 'leaderboard',
-  version = "2.8.0",
+  version = "2.10.0",
   author = 'David Czarnecki',
   author_email = "dczarnecki@agoragames.com",
   packages = ['leaderboard'],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [req.strip() for req in open('requirements.pip')]
 
 setup(
   name = 'leaderboard',
-  version = "2.10.0",
+  version = "2.8.0",
   author = 'David Czarnecki',
   author_email = "dczarnecki@agoragames.com",
   packages = ['leaderboard'],

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -297,6 +297,27 @@ class LeaderboardTest(unittest.TestCase):
         leaders[1]['member'].should.equal('member_15')
         leaders[2]['member'].should.equal('member_25')
 
+    def test_ranked_in_list_with_include_missing(self):
+        self.__rank_members_in_leaderboard(27)
+
+        # Without `include_missing`:
+        leaders = self.leaderboard.ranked_in_list(
+            ['member_1', 'member_15', 'member_25', 'member_200'])
+        len(leaders).should.be(4)
+        leaders[0]['member'].should.equal('member_1')
+        leaders[1]['member'].should.equal('member_15')
+        leaders[2]['member'].should.equal('member_25')
+        leaders[3]['member'].should.equal('member_200')
+
+        # With `include_missing`:
+        leaders = self.leaderboard.ranked_in_list(
+            ['member_1', 'member_15', 'member_25', 'member_200'],
+            include_missing=False)
+        len(leaders).should.be(3)
+        leaders[0]['member'].should.equal('member_1')
+        leaders[1]['member'].should.equal('member_15')
+        leaders[2]['member'].should.equal('member_25')
+
     def test_ranked_in_list_with_unknown_member(self):
         self.__rank_members_in_leaderboard(27)
         leaders = self.leaderboard.ranked_in_list(['jones'])


### PR DESCRIPTION
To determine whether or not to include members that are missing in the results.
Use case: If I have a list of friends, some of which have no score (aren't on the leaderboard) - I don't want to see them in the list of ranked users. Enter `include_missing`!