### PR TITLE
Remove `izip_longest` import where unneeded.

### DIFF
--- a/leaderboard/competition_ranking_leaderboard.py
+++ b/leaderboard/competition_ranking_leaderboard.py
@@ -1,7 +1,6 @@
 from .leaderboard import Leaderboard
 from redis import StrictRedis, Redis, ConnectionPool
 import math
-from itertools import izip_longest
 
 
 class CompetitionRankingLeaderboard(Leaderboard):

--- a/leaderboard/tie_ranking_leaderboard.py
+++ b/leaderboard/tie_ranking_leaderboard.py
@@ -2,7 +2,6 @@ from .leaderboard import Leaderboard
 from .leaderboard import grouper
 from redis import StrictRedis, Redis, ConnectionPool
 import math
-from itertools import izip_longest
 
 
 class TieRankingLeaderboard(Leaderboard):


### PR DESCRIPTION
It is not used by the CompetitionRanking or TieRanking leaderboards,
and causes issues with Python 3 when trying to use these.