### PR TITLE
Rank sort include missing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 3.7.2 (unreleased)
+## 3.7.2 (2018-05-03)
 
 * Fix running under Python 3 for `ranked_in_list(...)` if `include_missing` is `True` and non-member(s) passed in
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.7.2 (unreleased)
+
+* Fix running under Python 3 for `ranked_in_list(...)` if `include_missing` is `True` and non-member(s) passed in
+
 ## 3.7.1 (2018-02-20)
 
 * Fix `around_me_in` for Python 3+ [#49](https://github.com/agoragames/leaderboard-python/issues/49)

--- a/leaderboard/leaderboard.py
+++ b/leaderboard/leaderboard.py
@@ -16,7 +16,7 @@ def grouper(n, iterable, fillvalue=None):
 
 
 class Leaderboard(object):
-    VERSION = '3.5.0'
+    VERSION = '3.7.2'
     DEFAULT_PAGE_SIZE = 25
     DEFAULT_REDIS_HOST = 'localhost'
     DEFAULT_REDIS_PORT = 6379

--- a/leaderboard/leaderboard.py
+++ b/leaderboard/leaderboard.py
@@ -1083,13 +1083,13 @@ class Leaderboard(object):
             if self.RANK_KEY == options['sort_by']:
                 ranks_for_members = sorted(
                     ranks_for_members,
-                    key=lambda member: member[
-                        self.RANK_KEY])
+                    key=lambda member: member.get(self.RANK_KEY) or -1
+                )
             elif self.SCORE_KEY == options['sort_by']:
                 ranks_for_members = sorted(
                     ranks_for_members,
-                    key=lambda member: member[
-                        self.SCORE_KEY])
+                    key=lambda member: member.get(self.SCORE_KEY) or -1
+                )
 
         return ranks_for_members
 

--- a/leaderboard/leaderboard.py
+++ b/leaderboard/leaderboard.py
@@ -1080,15 +1080,16 @@ class Leaderboard(object):
                     pass
 
         if 'sort_by' in options:
+            sort_value_if_none = float('-inf') if self.order == self.ASC else float('+inf')
             if self.RANK_KEY == options['sort_by']:
                 ranks_for_members = sorted(
                     ranks_for_members,
-                    key=lambda member: member.get(self.RANK_KEY) or -1
+                    key=lambda member: member.get(self.RANK_KEY) or sort_value_if_none
                 )
             elif self.SCORE_KEY == options['sort_by']:
                 ranks_for_members = sorted(
                     ranks_for_members,
-                    key=lambda member: member.get(self.SCORE_KEY) or -1
+                    key=lambda member: member.get(self.SCORE_KEY) or sort_value_if_none
                 )
 
         return ranks_for_members

--- a/run_tests
+++ b/run_tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import unittest
 from test.leaderboard import all_tests

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [req.strip() for req in open('requirements.pip')]
 
 setup(
   name = 'leaderboard',
-  version = "3.7.1",
+  version = "3.7.2",
   author = 'David Czarnecki',
   author_email = "dczarnecki@agoragames.com",
   packages = ['leaderboard'],

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -668,6 +668,14 @@ class LeaderboardTest(unittest.TestCase):
         leaders[1]['member'].should.equal('member_25')
         leaders[2]['member'].should.equal('member_81')
 
+        self.leaderboard.order = Leaderboard.ASC
+        leaders = self.leaderboard.ranked_in_list(
+            ['member_1', 'member_81', 'member_25'], sort_by='rank')
+        len(leaders).should.equal(3)
+        leaders[0]['member'].should.equal('member_81')
+        leaders[1]['member'].should.equal('member_1')
+        leaders[2]['member'].should.equal('member_25')
+
     def __rank_members_in_leaderboard(self, members_to_add=6):
         for index in range(1, members_to_add):
             self.leaderboard.rank_member(

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -647,18 +647,26 @@ class LeaderboardTest(unittest.TestCase):
         leaders = self.leaderboard.ranked_in_list(
             ['member_1', 'member_81', 'member_25'], sort_by='rank')
         len(leaders).should.equal(3)
+        leaders[0]['member'].should.equal('member_25')
+        leaders[1]['member'].should.equal('member_1')
+        leaders[2]['member'].should.equal('member_81')
+
+        self.leaderboard.order = Leaderboard.ASC
+        leaders = self.leaderboard.ranked_in_list(
+            ['member_1', 'member_81', 'member_25'], sort_by='rank')
+        len(leaders).should.equal(3)
         leaders[0]['member'].should.equal('member_81')
-        leaders[1]['member'].should.equal('member_25')
-        leaders[2]['member'].should.equal('member_1')
+        leaders[1]['member'].should.equal('member_1')
+        leaders[2]['member'].should.equal('member_25')
 
     def test_ranked_in_list_with_include_missing_sort_by_score_and_missing_members(self):
         self.__rank_members_in_leaderboard(27)
         leaders = self.leaderboard.ranked_in_list(
             ['member_1', 'member_81', 'member_25'], sort_by='score')
         len(leaders).should.equal(3)
-        leaders[0]['member'].should.equal('member_81')
-        leaders[1]['member'].should.equal('member_1')
-        leaders[2]['member'].should.equal('member_25')
+        leaders[0]['member'].should.equal('member_1')
+        leaders[1]['member'].should.equal('member_25')
+        leaders[2]['member'].should.equal('member_81')
 
     def __rank_members_in_leaderboard(self, members_to_add=6):
         for index in range(1, members_to_add):

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -642,6 +642,24 @@ class LeaderboardTest(unittest.TestCase):
 
         self.leaderboard.total_scores().should.equal(325.0)
 
+    def test_ranked_in_list_with_include_missing_sort_by_rank_and_missing_members(self):
+        self.__rank_members_in_leaderboard(27)
+        leaders = self.leaderboard.ranked_in_list(
+            ['member_1', 'member_81', 'member_25'], sort_by='rank')
+        len(leaders).should.equal(3)
+        leaders[0]['member'].should.equal('member_81')
+        leaders[1]['member'].should.equal('member_25')
+        leaders[2]['member'].should.equal('member_1')
+
+    def test_ranked_in_list_with_include_missing_sort_by_score_and_missing_members(self):
+        self.__rank_members_in_leaderboard(27)
+        leaders = self.leaderboard.ranked_in_list(
+            ['member_1', 'member_81', 'member_25'], sort_by='score')
+        len(leaders).should.equal(3)
+        leaders[0]['member'].should.equal('member_81')
+        leaders[1]['member'].should.equal('member_1')
+        leaders[2]['member'].should.equal('member_25')
+
     def __rank_members_in_leaderboard(self, members_to_add=6):
         for index in range(1, members_to_add):
             self.leaderboard.rank_member(

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -18,7 +18,7 @@ class LeaderboardTest(unittest.TestCase):
         Leaderboard.MEMBER_DATA_KEY = 'member_data'
 
     def test_version(self):
-        Leaderboard.VERSION.should.equal('3.5.0')
+        Leaderboard.VERSION.should.equal('3.7.2')
 
     def test_init_with_defaults(self):
         'name'.should.equal(self.leaderboard.leaderboard_name)


### PR DESCRIPTION
Fix running under Python 3 for `ranked_in_list(...)` if `include_missing` is `True` and non-member(s) passed in