### PR TITLE
Add support for redis-py 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ highscore_lb.score_for('david')
 ### Ranking a member across multiple leaderboards
 
 ```python
-highscore_lb.rank_member_across(['highscores', 'more_highscores'], 'david', 50000, { 'member_name': 'david' })
+highscore_lb.rank_member_across(['highscores', 'more_highscores'], 'david', 50000, str({'member_name': 'david'}))
 ```
 
 ### Alternate leaderboard types

--- a/leaderboard/leaderboard.py
+++ b/leaderboard/leaderboard.py
@@ -136,9 +136,9 @@ class Leaderboard(object):
         '''
         pipeline = self.redis_connection.pipeline()
         if isinstance(self.redis_connection, Redis):
-            pipeline.zadd(leaderboard_name, member, score)
+            pipeline.zadd(leaderboard_name, {member: score})
         else:
-            pipeline.zadd(leaderboard_name, score, member)
+            pipeline.zadd(leaderboard_name, {score: member})
         if member_data:
             pipeline.hset(
                 self._member_data_key(leaderboard_name),
@@ -159,9 +159,9 @@ class Leaderboard(object):
         pipeline = self.redis_connection.pipeline()
         for leaderboard_name in leaderboards:
             if isinstance(self.redis_connection, Redis):
-                pipeline.zadd(leaderboard_name, member, score)
+                pipeline.zadd(leaderboard_name, {member: score})
             else:
-                pipeline.zadd(leaderboard_name, score, member)
+                pipeline.zadd(leaderboard_name, {score: member})
             if member_data:
                 pipeline.hset(
                     self._member_data_key(leaderboard_name),
@@ -241,9 +241,9 @@ class Leaderboard(object):
         pipeline = self.redis_connection.pipeline()
         for member, score in grouper(2, members_and_scores):
             if isinstance(self.redis_connection, Redis):
-                pipeline.zadd(leaderboard_name, member, score)
+                pipeline.zadd(leaderboard_name, {member: score})
             else:
-                pipeline.zadd(leaderboard_name, score, member)
+                pipeline.zadd(leaderboard_name, {score: member})
         pipeline.execute()
 
     def member_data_for(self, member):
@@ -546,7 +546,7 @@ class Leaderboard(object):
         @param member_data [String] Optional member data.
         '''
         pipeline = self.redis_connection.pipeline()
-        pipeline.zincrby(leaderboard_name, member, delta)
+        pipeline.zincrby(leaderboard_name, delta, member)
         if member_data:
             pipeline.hset(
                 self._member_data_key(leaderboard_name),

--- a/leaderboard/tie_ranking_leaderboard.py
+++ b/leaderboard/tie_ranking_leaderboard.py
@@ -60,11 +60,11 @@ class TieRankingLeaderboard(Leaderboard):
 
         pipeline = self.redis_connection.pipeline()
         if isinstance(self.redis_connection, Redis):
-            pipeline.zadd(leaderboard_name, member, new_score)
-            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name), str(float(new_score)), new_score)
+            pipeline.zadd(leaderboard_name, {member: new_score})
+            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name), {str(float(new_score)): new_score})
         else:
-            pipeline.zadd(leaderboard_name, new_score, member)
-            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name), new_score, str(float(new_score)))
+            pipeline.zadd(leaderboard_name, {new_score: member})
+            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name), {new_score: str(float(new_score))})
         if member_data:
             pipeline.hset(
                 self._member_data_key(leaderboard_name),
@@ -92,16 +92,13 @@ class TieRankingLeaderboard(Leaderboard):
 
         pipeline = self.redis_connection.pipeline()
         if isinstance(self.redis_connection, Redis):
-            pipeline.zadd(leaderboard_name, member, score)
-            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name),
-                          str(float(score)), score)
+            pipeline.zadd(leaderboard_name, {member: score})
+            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name), {str(float(score)): score})
         else:
-            pipeline.zadd(leaderboard_name, score, member)
-            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name),
-                          score, str(float(score)))
+            pipeline.zadd(leaderboard_name, {score: member})
+            pipeline.zadd(self._ties_leaderboard_key(leaderboard_name), {score: str(float(score))})
         if can_delete_score:
-            pipeline.zrem(self._ties_leaderboard_key(leaderboard_name),
-                          str(float(member_score)))
+            pipeline.zrem(self._ties_leaderboard_key(leaderboard_name), str(float(member_score)))
         if member_data:
             pipeline.hset(
                 self._member_data_key(leaderboard_name),

--- a/test/leaderboard/competition_ranking_leaderboard_test.py
+++ b/test/leaderboard/competition_ranking_leaderboard_test.py
@@ -153,7 +153,7 @@ class CompetitionRankingLeaderboardTest(unittest.TestCase):
     def __rank_members_in_leaderboard(self, members_to_add=6):
         for index in range(1, members_to_add):
             self.leaderboard.rank_member(
-                'member_%s' %
-                index, index, {
-                    'member_name': 'Leaderboard member %s' %
-                    index})
+                'member_%s' % index,
+                index,
+                str({'member_name': 'Leaderboard member %s' % index})
+            )

--- a/test/leaderboard/leaderboard_test.py
+++ b/test/leaderboard/leaderboard_test.py
@@ -70,8 +70,7 @@ class LeaderboardTest(unittest.TestCase):
     def test_update_member_data(self):
         self.__rank_members_in_leaderboard()
         self.leaderboard.update_member_data(
-            'member_1', {
-                'member_name': 'Updated Leaderboard member 1'})
+            'member_1', str({'member_name': 'Updated Leaderboard member 1'}))
         self.leaderboard.member_data_for('member_1').should.eql(
             str({'member_name': 'Updated Leaderboard member 1'}))
 
@@ -498,7 +497,7 @@ class LeaderboardTest(unittest.TestCase):
 
     def test_rank_member_across(self):
         self.leaderboard.rank_member_across(
-            ['highscores', 'more_highscores'], 'david', 50000, {'member_name': 'david'})
+            ['highscores', 'more_highscores'], 'david', 50000, str({'member_name': 'david'}))
         len(self.leaderboard.leaders_in('highscores', 1)).should.equal(1)
         len(self.leaderboard.leaders_in('more_highscores', 1)).should.equal(1)
 
@@ -692,7 +691,7 @@ class LeaderboardTest(unittest.TestCase):
     def __rank_members_in_leaderboard(self, members_to_add=6):
         for index in range(1, members_to_add):
             self.leaderboard.rank_member(
-                'member_%s' %
-                index, index, {
-                    'member_name': 'Leaderboard member %s' %
-                    index})
+                'member_%s' % index,
+                index,
+                str({'member_name': 'Leaderboard member %s' % index})
+            )

--- a/test/leaderboard/reverse_tie_ranking_leaderboard_test.py
+++ b/test/leaderboard/reverse_tie_ranking_leaderboard_test.py
@@ -187,7 +187,7 @@ class ReverseTieRankingLeaderboardTest(unittest.TestCase):
     def __rank_members_in_leaderboard(self, members_to_add=6):
         for index in range(1, members_to_add):
             self.leaderboard.rank_member(
-                'member_%s' %
-                index, index, {
-                    'member_name': 'Leaderboard member %s' %
-                    index})
+                'member_%s' % index,
+                index,
+                str({'member_name': 'Leaderboard member %s' % index})
+            )

--- a/test/leaderboard/tie_ranking_leaderboard_test.py
+++ b/test/leaderboard/tie_ranking_leaderboard_test.py
@@ -242,7 +242,7 @@ class TieRankingLeaderboardTest(unittest.TestCase):
     def __rank_members_in_leaderboard(self, members_to_add=6):
         for index in range(1, members_to_add):
             self.leaderboard.rank_member(
-                'member_%s' %
-                index, index, {
-                    'member_name': 'Leaderboard member %s' %
-                    index})
+                'member_%s' % index,
+                index,
+                str({'member_name': 'Leaderboard member %s' % index})
+            )


### PR DESCRIPTION
redis-py 3.X introduced some breaking changes that made this project incompatible, this PR adds support for these changes and fix tests were applicabble. Follows some redis-py changes:

https://github.com/andymccurdy/redis-py#mset-msetnx-and-zadd
> MSET, MSETNX and ZADD
> These commands all accept a mapping of key/value pairs. In redis-py 2.X this mapping could be specified as *args or as **kwargs. Both of these styles caused issues when Redis introduced optional flags to ZADD. Relying on *args caused issues with the optional argument order, especially in Python 2.7. Relying on **kwargs caused potential collision issues of user keys with the argument names in the method signature.

https://github.com/andymccurdy/redis-py#encoding-of-user-input
> redis-py 3.0 only accepts user data as bytes, strings or numbers (ints, longs and floats). Attempting to specify a key or a value as any other type will raise a DataError exception.

https://github.com/andymccurdy/redis-py#zincrby
> redis-py 2.X accidentily modified the argument order of ZINCRBY, swapping the order of value and amount

So this PR change all ZADD calls to supply keys and values as a dict instead of positional arguments, and it also update tests to provide `member_data` as string instead of dict, as stated in docstring methods, these data should be provided in string already. 

Fixes #61