### PR TITLE
Fix TieRankingLeaderboard.rank_member_across

### DIFF
--- a/leaderboard/tie_ranking_leaderboard.py
+++ b/leaderboard/tie_ranking_leaderboard.py
@@ -120,7 +120,7 @@ class TieRankingLeaderboard(Leaderboard):
         @param member_data [String] Optional member data.
         '''
         for leaderboard_name in leaderboards:
-            self.rank_member_in(leaderboard, member, score, member_data)
+            self.rank_member_in(leaderboard_name, member, score, member_data)
 
     def rank_members_in(self, leaderboard_name, members_and_scores):
         '''

--- a/test/leaderboard/tie_ranking_leaderboard_test.py
+++ b/test/leaderboard/tie_ranking_leaderboard_test.py
@@ -230,6 +230,12 @@ class TieRankingLeaderboardTest(unittest.TestCase):
         self.leaderboard.rank_for('member_1').should.equal(2)
         self.leaderboard.rank_for('member_2').should.equal(2)
 
+    def test_rank_member_across(self):
+        self.leaderboard.rank_member_across(
+            ['highscores', 'more_highscores'], 'david', 50000, {'member_name': 'david'})
+        len(self.leaderboard.leaders_in('highscores', 1)).should.equal(1)
+        len(self.leaderboard.leaders_in('more_highscores', 1)).should.equal(1)
+
     def test_it_should_correctly_pop_ties_namespace_from_options(self):
         self.leaderboard = TieRankingLeaderboard('ties', ties_namespace='ties_namespace')
         self.__rank_members_in_leaderboard(26)


### PR DESCRIPTION
Pulled this fix out as requested in #64 