### PR TITLE
Use decode_responses=True for python3 support in tests

### DIFF
--- a/test/leaderboard/competition_ranking_leaderboard_test.py
+++ b/test/leaderboard/competition_ranking_leaderboard_test.py
@@ -1,14 +1,12 @@
-from redis import Redis, StrictRedis, ConnectionPool
 from leaderboard.competition_ranking_leaderboard import CompetitionRankingLeaderboard
 import unittest
-import time
 import sure
 
 
 class CompetitionRankingLeaderboardTest(unittest.TestCase):
 
     def setUp(self):
-        self.leaderboard = CompetitionRankingLeaderboard('ties')
+        self.leaderboard = CompetitionRankingLeaderboard('ties', decode_responses=True)
 
     def tearDown(self):
         self.leaderboard.redis_connection.flushdb()

--- a/test/leaderboard/reverse_competition_ranking_leaderboard_test.py
+++ b/test/leaderboard/reverse_competition_ranking_leaderboard_test.py
@@ -1,8 +1,6 @@
-from redis import Redis, StrictRedis, ConnectionPool
 from leaderboard.leaderboard import Leaderboard
 from leaderboard.competition_ranking_leaderboard import CompetitionRankingLeaderboard
 import unittest
-import time
 import sure
 
 
@@ -10,7 +8,7 @@ class ReverseCompetitionRankingLeaderboardTest(unittest.TestCase):
 
     def setUp(self):
         self.leaderboard = CompetitionRankingLeaderboard(
-            'ties', order=Leaderboard.ASC)
+            'ties', order=Leaderboard.ASC, decode_responses=True)
 
     def tearDown(self):
         self.leaderboard.redis_connection.flushdb()

--- a/test/leaderboard/reverse_tie_ranking_leaderboard_test.py
+++ b/test/leaderboard/reverse_tie_ranking_leaderboard_test.py
@@ -1,4 +1,3 @@
-from redis import Redis, StrictRedis, ConnectionPool
 from leaderboard.leaderboard import Leaderboard
 from leaderboard.tie_ranking_leaderboard import TieRankingLeaderboard
 import unittest
@@ -9,7 +8,7 @@ import sure
 class ReverseTieRankingLeaderboardTest(unittest.TestCase):
 
     def setUp(self):
-        self.leaderboard = TieRankingLeaderboard('ties', order=Leaderboard.ASC)
+        self.leaderboard = TieRankingLeaderboard('ties', order=Leaderboard.ASC, decode_responses=True)
 
     def tearDown(self):
         self.leaderboard.redis_connection.flushdb()

--- a/test/leaderboard/tie_ranking_leaderboard_test.py
+++ b/test/leaderboard/tie_ranking_leaderboard_test.py
@@ -1,4 +1,3 @@
-from redis import Redis, StrictRedis, ConnectionPool
 from leaderboard.tie_ranking_leaderboard import TieRankingLeaderboard
 import unittest
 import time
@@ -8,7 +7,7 @@ import sure
 class TieRankingLeaderboardTest(unittest.TestCase):
 
     def setUp(self):
-        self.leaderboard = TieRankingLeaderboard('ties')
+        self.leaderboard = TieRankingLeaderboard('ties', decode_responses=True)
 
     def tearDown(self):
         self.leaderboard.redis_connection.flushdb()


### PR DESCRIPTION
This option tells the driver to decode bytes to str in Python3 and has no affect in Python2.